### PR TITLE
Fix paths in biceps case

### DIFF
--- a/opendihu_examples/isometric_contraction/biceps_muscle/BayesOpt_biceps_muscle.py
+++ b/opendihu_examples/isometric_contraction/biceps_muscle/BayesOpt_biceps_muscle.py
@@ -199,7 +199,7 @@ def simulation(force):
     f.close()
     
     # we look at the max in absolute value, and we assume it will be negative
-    maxtraction = min((tractionz_rank0+tractionz_rank1+tractionz_rank2+tractionz_rank3)/4)
+    maxtraction = min((np.array(tractionz_rank0)+np.array(tractionz_rank1)+np.array(tractionz_rank2)+np.array(tractionz_rank3))/4)
 
     print("The maximum traction was ", maxtraction)
     f = open("muscle_bayes_" + str(force) + "N.csv", "a")

--- a/opendihu_examples/isometric_contraction/biceps_muscle/BayesOpt_biceps_muscle.py
+++ b/opendihu_examples/isometric_contraction/biceps_muscle/BayesOpt_biceps_muscle.py
@@ -192,7 +192,7 @@ def simulation(force):
         tractionz_rank3.extend([float(value) if value.strip() else 0 for value in row])
     f.close()
 
-    f = open("out/prestretch" + str(force) + "muscle_prestretch_rank0.csv")
+    f = open("out/prestretch" + str(force) + "/muscle_prestretch_rank0.csv")
     reader = csv.reader(f)
     for row in reader:
         length_after_prestretch = row[1]

--- a/opendihu_examples/isometric_contraction/biceps_muscle/BayesOpt_biceps_muscle.py
+++ b/opendihu_examples/isometric_contraction/biceps_muscle/BayesOpt_biceps_muscle.py
@@ -168,31 +168,31 @@ def simulation(force):
     tractionz_rank2 = []
     tractionz_rank3 = []
 
-    f = open("/out/prestretch" + str(force) + "/muscle_contraction_rank0.csv")
+    f = open("out/prestretch" + str(force) + "/muscle_contraction_rank0.csv")
     reader = csv.reader(f)
     for row in reader:
         tractionz_rank0.extend([float(value) if value.strip() else 0 for value in row])
     f.close()
 
-    f = open("/out/prestretch" + str(force) + "/muscle_contraction_rank1.csv")
+    f = open("out/prestretch" + str(force) + "/muscle_contraction_rank1.csv")
     reader = csv.reader(f)
     for row in reader:
         tractionz_rank1.extend([float(value) if value.strip() else 0 for value in row])
     f.close()
 
-    f = open("/out/prestretch" + str(force) + "/muscle_contraction_rank2.csv")
+    f = open("out/prestretch" + str(force) + "/muscle_contraction_rank2.csv")
     reader = csv.reader(f)
     for row in reader:
         tractionz_rank2.extend([float(value) if value.strip() else 0 for value in row])
     f.close()
 
-    f = open("/out/prestretch" + str(force) + "/muscle_contraction_rank3.csv")
+    f = open("out/prestretch" + str(force) + "/muscle_contraction_rank3.csv")
     reader = csv.reader(f)
     for row in reader:
         tractionz_rank3.extend([float(value) if value.strip() else 0 for value in row])
     f.close()
 
-    f = open("/out/prestretch" + str(force) + "muscle_prestretch_rank0.csv")
+    f = open("out/prestretch" + str(force) + "muscle_prestretch_rank0.csv")
     reader = csv.reader(f)
     for row in reader:
         length_after_prestretch = row[1]

--- a/opendihu_examples/isometric_contraction/biceps_muscle/BayesOpt_biceps_muscle.py
+++ b/opendihu_examples/isometric_contraction/biceps_muscle/BayesOpt_biceps_muscle.py
@@ -168,37 +168,38 @@ def simulation(force):
     tractionz_rank2 = []
     tractionz_rank3 = []
 
-    f = open("/out/" + str(force) + "/muscle_contraction_rank0.csv")
+    f = open("/out/prestretch" + str(force) + "/muscle_contraction_rank0.csv")
     reader = csv.reader(f)
     for row in reader:
         tractionz_rank0.extend([float(value) if value.strip() else 0 for value in row])
     f.close()
 
-    f = open("/out/" + str(force) + "/muscle_contraction_rank1.csv")
+    f = open("/out/prestretch" + str(force) + "/muscle_contraction_rank1.csv")
     reader = csv.reader(f)
     for row in reader:
         tractionz_rank1.extend([float(value) if value.strip() else 0 for value in row])
     f.close()
 
-    f = open("/out/" + str(force) + "/muscle_contraction_rank2.csv")
+    f = open("/out/prestretch" + str(force) + "/muscle_contraction_rank2.csv")
     reader = csv.reader(f)
     for row in reader:
         tractionz_rank2.extend([float(value) if value.strip() else 0 for value in row])
     f.close()
 
-    f = open("/out/" + str(force) + "/muscle_contraction_rank3.csv")
+    f = open("/out/prestretch" + str(force) + "/muscle_contraction_rank3.csv")
     reader = csv.reader(f)
     for row in reader:
         tractionz_rank3.extend([float(value) if value.strip() else 0 for value in row])
     f.close()
 
-    f = open("/out/" + str(force) + "muscle_prestretch_rank0.csv")
+    f = open("/out/prestretch" + str(force) + "muscle_prestretch_rank0.csv")
     reader = csv.reader(f)
     for row in reader:
         length_after_prestretch = row[1]
     f.close()
     
-    maxtraction = max((tractionz_rank0+tractionz_rank1+tractionz_rank2+tractionz_rank3)/4)
+    # we look at the max in absolute value, and we assume it will be negative
+    maxtraction = min((tractionz_rank0+tractionz_rank1+tractionz_rank2+tractionz_rank3)/4)
 
     print("The maximum traction was ", maxtraction)
     f = open("muscle_bayes_" + str(force) + "N.csv", "a")

--- a/opendihu_examples/isometric_contraction/biceps_muscle/helper.py
+++ b/opendihu_examples/isometric_contraction/biceps_muscle/helper.py
@@ -98,7 +98,7 @@ if variables.paraview_output:
     subfolder = "paraview/"
   variables.output_writer_emg.append({"format": "Paraview", "outputInterval": int(1./variables.dt_3D*variables.output_timestep_3D_emg), "filename": "out/" + subfolder + variables.scenario_name + "/hd_emg", "binary": True, "fixedFormat": False, "combineFiles": True, "fileNumbering": "incremental"})
   variables.output_writer_elasticity.append({"format": "Paraview", "outputInterval": int(1./variables.dt_3D*variables.output_timestep_3D), "filename": "out/" + subfolder + variables.scenario_name + "/elasticity", "binary": True, "fixedFormat": False, "combineFiles": True, "fileNumbering": "incremental"})
-  variables.output_writer_fibers.append({"format": "Paraview", "outputInterval": int(1./variables.dt_splitting*variables.output_timestep_fibers), "filename": "out/" + subfolder + variables.scenario_name + "/fibers", "binary": True, "fixedFormat": False, "combineFiles": True, "fileNumbering": "incremental"})
+  variables.output_writer_fibers.append({"format": "Paraview", "outputInterval": int(variables.dt_3D/variables.dt_splitting), "filename": "out/prestretch"+float(variables.prestretch_force) + "/fibers", "binary": True, "fixedFormat": False, "combineFiles": True, "fileNumbering": "incremental"})
   if variables.states_output:
     variables.output_writer_0D_states.append({"format": "Paraview", "outputInterval": 1, "filename": "out/" + subfolder + variables.scenario_name + "/0D_states", "binary": True, "fixedFormat": False, "combineFiles": True, "fileNumbering": "incremental"})
 
@@ -471,7 +471,7 @@ def callback_function_prestretch(raw_data):
 
     average_z_start /= number_of_nodes
  
-    f = open("out/"+variables.scenario_name+"/muscle_prestretch.csv", "a")
+    f = open("out/prestretch"+float(variables.prestretch_force)+"/muscle_prestretch.csv", "a")
     f.write(str(average_z_start))
     f.write(",")
     f.close()
@@ -487,7 +487,7 @@ def callback_function_prestretch(raw_data):
         average_z_start += z_data[i]
       average_z_start /= number_of_nodes
   
-      f = open("out/"+variables.scenario_name+"/muscle_prestretch_rank" + str(rank_no) + ".csv", "a")
+      f = open("out/prestretch"+float(variables.prestretch_force)+"/muscle_prestretch_rank" + str(rank_no) + ".csv", "a")
       f.write(str(average_z_start))
       f.write(",")
       f.close()

--- a/opendihu_examples/isometric_contraction/biceps_muscle/helper.py
+++ b/opendihu_examples/isometric_contraction/biceps_muscle/helper.py
@@ -98,7 +98,7 @@ if variables.paraview_output:
     subfolder = "paraview/"
   variables.output_writer_emg.append({"format": "Paraview", "outputInterval": int(1./variables.dt_3D*variables.output_timestep_3D_emg), "filename": "out/" + subfolder + variables.scenario_name + "/hd_emg", "binary": True, "fixedFormat": False, "combineFiles": True, "fileNumbering": "incremental"})
   variables.output_writer_elasticity.append({"format": "Paraview", "outputInterval": int(1./variables.dt_3D*variables.output_timestep_3D), "filename": "out/" + subfolder + variables.scenario_name + "/elasticity", "binary": True, "fixedFormat": False, "combineFiles": True, "fileNumbering": "incremental"})
-  variables.output_writer_fibers.append({"format": "Paraview", "outputInterval": int(variables.dt_3D/variables.dt_splitting), "filename": "out/prestretch"+float(variables.prestretch_force) + "/fibers", "binary": True, "fixedFormat": False, "combineFiles": True, "fileNumbering": "incremental"})
+  variables.output_writer_fibers.append({"format": "Paraview", "outputInterval": int(variables.dt_3D/variables.dt_splitting), "filename": "out/prestretch"+str(variables.prestretch_force) + "/fibers", "binary": True, "fixedFormat": False, "combineFiles": True, "fileNumbering": "incremental"})
   if variables.states_output:
     variables.output_writer_0D_states.append({"format": "Paraview", "outputInterval": 1, "filename": "out/" + subfolder + variables.scenario_name + "/0D_states", "binary": True, "fixedFormat": False, "combineFiles": True, "fileNumbering": "incremental"})
 
@@ -471,7 +471,7 @@ def callback_function_prestretch(raw_data):
 
     average_z_start /= number_of_nodes
  
-    f = open("out/prestretch"+float(variables.prestretch_force)+"/muscle_prestretch.csv", "a")
+    f = open("out/prestretch"+str(variables.prestretch_force)+"/muscle_prestretch.csv", "a")
     f.write(str(average_z_start))
     f.write(",")
     f.close()
@@ -487,7 +487,7 @@ def callback_function_prestretch(raw_data):
         average_z_start += z_data[i]
       average_z_start /= number_of_nodes
   
-      f = open("out/prestretch"+float(variables.prestretch_force)+"/muscle_prestretch_rank" + str(rank_no) + ".csv", "a")
+      f = open("out/prestretch"+str(variables.prestretch_force)+"/muscle_prestretch_rank" + str(rank_no) + ".csv", "a")
       f.write(str(average_z_start))
       f.write(",")
       f.close()
@@ -508,7 +508,7 @@ def callback_function_contraction(raw_data):
 
     average_z_start /= number_of_nodes
  
-    f = open("out/"+variables.scenario_name+"/muscle_contraction.csv", "a")
+    f = open("out/prestretch"+str(variables.prestretch_force)+"/muscle_contraction.csv", "a")
     f.write(str(average_z_start))
     f.write(",")
     f.close()
@@ -525,7 +525,7 @@ def callback_function_contraction(raw_data):
         average_z_start += z_data[i]
       average_z_start /= number_of_nodes
   
-      f = open("out/"+variables.scenario_name+"/muscle_contraction_rank" + str(rank_no) + ".csv", "a")
+      f = open("out/prestretch"+str(variables.prestretch_force)+"/muscle_contraction_rank" + str(rank_no) + ".csv", "a")
       f.write(str(average_z_start))
       f.write(",")
       f.close()

--- a/opendihu_examples/isometric_contraction/biceps_muscle/settings_contraction_with_prestretch.py
+++ b/opendihu_examples/isometric_contraction/biceps_muscle/settings_contraction_with_prestretch.py
@@ -424,7 +424,7 @@ config = {
               
               # Paraview files
               #{"format": "Paraview", "outputInterval": 1, "filename": "out/"+variables.scenario_name+"/u", "binary": True, "fixedFormat": False, "onlyNodalValues":True, "combineFiles":True, "fileNumbering": "incremental"},
-              {"format": "Paraview", "outputInterval": 1, "filename": "out/"+variables.scenario_name+"/prestretch", "binary": True, "fixedFormat": False, "onlyNodalValues":True, "combineFiles":True, "fileNumbering": "incremental"},
+              {"format": "Paraview", "outputInterval": 1, "filename": "out/prestretch"+float(variables.prestretch_force)+"/prestretch", "binary": True, "fixedFormat": False, "onlyNodalValues":True, "combineFiles":True, "fileNumbering": "incremental"},
               # Python callback function "postprocess"
               {"format": "PythonCallback", "outputInterval": 1, "callback": callback_function_prestretch, "onlyNodalValues":True, "filename": ""},
             ],
@@ -614,7 +614,7 @@ config = {
           "lambdaDotScalingFactor":       variables.lambda_dot_scaling_factor,     # scaling factor for the output of the lambda dot slot, i.e. the contraction velocity. Use this to scale the unit-less quantity to, e.g., micrometers per millisecond for the subcellular model.
           "slotNames":                    ["lambda", "ldot", "gamma", "T"],   # names of the data slots (lamdba, lambdaDot, gamma, traction), maximum 10 characters per slot name
           "OutputWriter" : [
-            {"format": "Paraview", "outputInterval": 1, "filename": "out/" + variables.scenario_name + "/contraction_mechanics_3D", "binary": True, "fixedFormat": False, "onlyNodalValues":True, "combineFiles":True, "fileNumbering": "incremental"},
+            {"format": "Paraview", "outputInterval": 1, "filename": "out/prestretch"+float(variables.prestretch_force) + "/contraction_mechanics_3D", "binary": True, "fixedFormat": False, "onlyNodalValues":True, "combineFiles":True, "fileNumbering": "incremental"},
           ],
           "mapGeometryToMeshes":          [],                        # the mesh names of the meshes that will get the geometry transferred
           "dynamic":                      True,                      # if the dynamic solid mechanics solver should be used, else it computes the quasi-static problem

--- a/opendihu_examples/isometric_contraction/biceps_muscle/settings_contraction_with_prestretch.py
+++ b/opendihu_examples/isometric_contraction/biceps_muscle/settings_contraction_with_prestretch.py
@@ -415,8 +415,7 @@ config = {
             "extrapolateInitialGuess":     True,                                # if the initial values for the dynamic nonlinear problem should be computed by extrapolating the previous displacements and velocities
             "constantBodyForce":           variables.constant_body_force,       # a constant force that acts on the whole body, e.g. for gravity
             
-            "dirichletOutputFilename":     "out/"+variables.scenario_name+"/prestretch_dirichlet_boundary_conditions",                # filename for a vtp file that contains the Dirichlet boundary condition nodes and their values, set to None to disable
-            "totalForceLogFilename":       "out/"+variables.scenario_name+"/total_force.txt",                              # filename for a log file with the total force
+            "dirichletOutputFilename":     "out/prestretch"+str(variables.prestretch_force)+"/prestretch_dirichlet_boundary_conditions",                # filename for a vtp file that contains the Dirichlet boundary condition nodes and their values, set to None to disable
             
             # define which file formats should be written
             # 1. main output writer that writes output files using the quadratic elements function space. Writes displacements, velocities and PK2 stresses.
@@ -660,8 +659,7 @@ config = {
             "extrapolateInitialGuess":     True,                                # if the initial values for the dynamic nonlinear problem should be computed by extrapolating the previous displacements and velocities
             "constantBodyForce":           variables.constant_body_force,       # a constant force that acts on the whole body, e.g. for gravity
             
-            "dirichletOutputFilename":     "out/"+variables.scenario_name+"/contraction_dirichlet_boundary_conditions",                # filename for a vtp file that contains the Dirichlet boundary condition nodes and their values, set to None to disable
-            "totalForceLogFilename":       "out/"+variables.scenario_name+"/total_force.txt",                              # filename for a log file with the total force
+            "dirichletOutputFilename":     "out/prestretch"+str(variables.prestretch_force)+"/contraction_dirichlet_boundary_conditions",                # filename for a vtp file that contains the Dirichlet boundary condition nodes and their values, set to None to disable
             
             # define which file formats should be written
             # 1. main output writer that writes output files using the quadratic elements function space. Writes displacements, velocities and PK2 stresses.

--- a/opendihu_examples/isometric_contraction/biceps_muscle/settings_contraction_with_prestretch.py
+++ b/opendihu_examples/isometric_contraction/biceps_muscle/settings_contraction_with_prestretch.py
@@ -424,7 +424,7 @@ config = {
               
               # Paraview files
               #{"format": "Paraview", "outputInterval": 1, "filename": "out/"+variables.scenario_name+"/u", "binary": True, "fixedFormat": False, "onlyNodalValues":True, "combineFiles":True, "fileNumbering": "incremental"},
-              {"format": "Paraview", "outputInterval": 1, "filename": "out/prestretch"+float(variables.prestretch_force)+"/prestretch", "binary": True, "fixedFormat": False, "onlyNodalValues":True, "combineFiles":True, "fileNumbering": "incremental"},
+              {"format": "Paraview", "outputInterval": 1, "filename": "out/prestretch"+str(variables.prestretch_force)+"/prestretch", "binary": True, "fixedFormat": False, "onlyNodalValues":True, "combineFiles":True, "fileNumbering": "incremental"},
               # Python callback function "postprocess"
               {"format": "PythonCallback", "outputInterval": 1, "callback": callback_function_prestretch, "onlyNodalValues":True, "filename": ""},
             ],
@@ -614,7 +614,7 @@ config = {
           "lambdaDotScalingFactor":       variables.lambda_dot_scaling_factor,     # scaling factor for the output of the lambda dot slot, i.e. the contraction velocity. Use this to scale the unit-less quantity to, e.g., micrometers per millisecond for the subcellular model.
           "slotNames":                    ["lambda", "ldot", "gamma", "T"],   # names of the data slots (lamdba, lambdaDot, gamma, traction), maximum 10 characters per slot name
           "OutputWriter" : [
-            {"format": "Paraview", "outputInterval": 1, "filename": "out/prestretch"+float(variables.prestretch_force) + "/contraction_mechanics_3D", "binary": True, "fixedFormat": False, "onlyNodalValues":True, "combineFiles":True, "fileNumbering": "incremental"},
+            {"format": "Paraview", "outputInterval": 1, "filename": "out/prestretch"+str(variables.prestretch_force) + "/contraction_mechanics_3D", "binary": True, "fixedFormat": False, "onlyNodalValues":True, "combineFiles":True, "fileNumbering": "incremental"},
           ],
           "mapGeometryToMeshes":          [],                        # the mesh names of the meshes that will get the geometry transferred
           "dynamic":                      True,                      # if the dynamic solid mechanics solver should be used, else it computes the quasi-static problem


### PR DESCRIPTION
This PR improves the biceps case. 
- write the output files to a different folder named after the prestretch simulation.
- read  the files from the correct folder for optimization.