### PR TITLE
Fix writing traction to file

### DIFF
--- a/opendihu_examples/isometric_contraction/biceps_muscle/helper.py
+++ b/opendihu_examples/isometric_contraction/biceps_muscle/helper.py
@@ -501,7 +501,7 @@ def callback_function_contraction(raw_data):
     number_of_nodes = mx * my
     average_z_start = 0
 
-    z_data = raw_data[0]["data"][3]["components"][2]["values"]
+    z_data = raw_data[0]["data"][6]["components"][2]["values"]
 
     for i in range(number_of_nodes):
       average_z_start += z_data[i]
@@ -517,7 +517,7 @@ def callback_function_contraction(raw_data):
     number_of_nodes = mx * my
     average_z_start = 0
 
-    z_data = raw_data[0]["data"][3]["components"][2]["values"]
+    z_data = raw_data[0]["data"][6]["components"][2]["values"]
     
     if rank_no < 4:
 

--- a/opendihu_examples/isometric_contraction/cuboid_muscle/settings_contraction_with_prestretch.py
+++ b/opendihu_examples/isometric_contraction/cuboid_muscle/settings_contraction_with_prestretch.py
@@ -155,7 +155,7 @@ def callback_function_contraction(raw_data):
     average_z_start = 0
     average_z_end = 0
 
-    z_data = raw_data[0]["data"][3]["components"][2]["values"]
+    z_data = raw_data[0]["data"][6]["components"][2]["values"]
 
     for i in range(number_of_nodes):
       average_z_start += z_data[i]


### PR DESCRIPTION
While making experiments with the biceps, I realized that the values of traction at the bottom written to the file are negative, despite the values I observe in paraview are mostly positive. 
I investigated a bit more and compared values written to file to points in paraview and concluded that the index 3 does not correspond to the  traction, instead, it is the index 6. 

In addition I could confirm that the values that we add up in each rank correspond to the correct nodes. It is worth to mention, that not all ranks write the same amount of nodes, because nodes that are in between two ranks, only get written by one of them.  rank 0 makes a sum over 4 nodes, rank 1 & 2 make a sum over 6 nodes, and rank 3 makes a sum over 9 nodes. 

![image](https://github.com/user-attachments/assets/aa232dd5-3374-4552-b5dd-4f79da1e6bbc)

The rank in the image is written by rank 1. The global index 117, corresponds to the local index 0. 
