### PR TITLE
Change isometric to isotonic

### DIFF
--- a/opendihu_examples/isotonic_contraction/optimize_prestretch_length/cuboid_muscle/BayesOpt_cuboid_muscle.py
+++ b/opendihu_examples/isotonic_contraction/optimize_prestretch_length/cuboid_muscle/BayesOpt_cuboid_muscle.py
@@ -163,25 +163,16 @@ def simulation(force):
     print("end simulation")
 
     f = open("muscle_contraction_" + str(force) + "_extension.csv")
-    reader = csv.reader(f)
-    tractionz = []
+    reader = csv.reader(f, delimiter=",")
+    muscle_length_process = []
     for row in reader:
-        tractionz.extend([float(value) if value.strip() else 0 for value in row])
+        for j in row:
+            muscle_length_process.append(j)
+    contraction = float(muscle_length_process[0]) - float(muscle_length_process[-2])
+    print("The muscle contracted ", contraction)
     f.close()
 
-    f = open("length_after_prestretch_" + str(force) + "_extension.csv")
-    reader = csv.reader(f)
-    for row in reader:
-        length_after_prestretch = row[0]
-    f.close()
-    
-    maxtraction = max(tractionz)
-    print("The maximum traction was ", maxtraction)
-    f = open("muscle_bayes_" + str(force) + "_extension.csv", "a")
-    f.write(str(force) + " " + str(maxtraction) + " " + str(length_after_prestretch))
-    f.write("\n")
-    f.close()
-    return maxtraction
+    return contraction
 
 
 class CustomSingleTaskGP(SingleTaskGP):

--- a/opendihu_examples/isotonic_contraction/optimize_prestretch_length/cuboid_muscle/README.md
+++ b/opendihu_examples/isotonic_contraction/optimize_prestretch_length/cuboid_muscle/README.md
@@ -2,7 +2,7 @@
 
 ## Setup
 - A dummy cuboid muscle geometry. 
-- The solvers for both stretching and contraction are coupled mechanics solver and fastmonodomain solver. In the prestretch process we set dynamic to `False` and add boundary conditions that simulate the muscle being fixed at one side and being pulled at from the other side until it has reached a given length. In the contraction process we set dynamic to `True` and let the ends of the muscle free.
+- The solvers for both stretching and contraction are coupled mechanics solver and fastmonodomain solver. In the prestretch process we set dynamic to `False` and add boundary conditions that simulate the muscle being fixed at one side and being pulled at from the other side until it has reached a given length. In the contraction process we set dynamic to `True` and let one end of the muscle free.
 - It uses the electrophysiology CellML model "hodgkin_huxley-razumova" and the incompressible mechanics model "Mooney-Rivlin".
 - No preCICE involved. 
 

--- a/opendihu_examples/isotonic_contraction/optimize_prestretch_length/cuboid_muscle/settings_contraction_with_prestretch.py
+++ b/opendihu_examples/isotonic_contraction/optimize_prestretch_length/cuboid_muscle/settings_contraction_with_prestretch.py
@@ -61,7 +61,7 @@ for j in range(variables.bs_y):
     elasticity_dirichlet_bc[(variables.bs_z-1)*variables.bs_x*variables.bs_y + j*variables.bs_x + i] = [None,None,prestretch_extension,None,None,None]
 
     contraction_elasticity_dirichlet_bc[k*variables.bs_x*variables.bs_y + j*variables.bs_x + i] = [None,None,0.0,None,None,None]
-    contraction_elasticity_dirichlet_bc[(variables.bs_z-1)*variables.bs_x*variables.bs_y + j*variables.bs_x + i] = [None,None,0.0,None,None,None]
+    #contraction_elasticity_dirichlet_bc[(variables.bs_z-1)*variables.bs_x*variables.bs_y + j*variables.bs_x + i] = [None,None,0.0,None,None,None]
 
 # fix left edge 
 for j in range(variables.bs_y):
@@ -108,20 +108,27 @@ def callback_function_contraction(raw_data):
     average_z_start = 0
     average_z_end = 0
 
-    z_data = raw_data[0]["data"][3]["components"][2]["values"]
+    z_data = raw_data[0]["data"][0]["components"][2]["values"]
 
-    for i in range(number_of_nodes):
-      average_z_start += z_data[i]
-      average_z_end += z_data[number_of_nodes*(variables.bs_z -1) + i]
+  for i in range(number_of_nodes):
+    average_z_start += z_data[i]
+    average_z_end += z_data[number_of_nodes*(variables.bs_z -1) + i]
 
-    average_z_start /= number_of_nodes
-    average_z_end /= number_of_nodes
- 
-    f = open("muscle_contraction_" + str(prestretch_extension) + "_extension.csv", "a")
-    f.write(str(average_z_start))
+  average_z_start /= number_of_nodes
+  average_z_end /= number_of_nodes
+
+  length_of_muscle = np.abs(average_z_end - average_z_start)
+  print("length of muscle: ", length_of_muscle)
+
+  if t == variables.dt_3D:
+    f = open("muscle_contraction_" + str(prestretch_extension) + "_extension.csv", "w")
+    f.write(str(length_of_muscle))
     f.write(",")
-    #f.write(str(t) + " " + str(average_z_start) + " " + str(average_z_end) + "")
-    #f.write("\n")
+    f.close()
+  else:
+    f = open("muscle_contraction_" + str(prestretch_extension) + "_extension.csv", "a")
+    f.write(str(length_of_muscle))
+    f.write(",")
     f.close()
 
 


### PR DESCRIPTION
## Main changes of this PR

**Issues that are addressed by this PR:** 
The isotonic case "optimize_prestretch_length/cuboid_muscle" was isometric. It now is isotonic.

**Features that have been added:**


## Additional information
The Dirichlet BC are keeping one end in place at let one end free.

## Author's checklist

* [x] I updated the documentation.
* [x] I checked that everything compiles and runs as it should.