### PR TITLE
Fix interpolation bug

### DIFF
--- a/opendihu_examples/paired_muscles/cuboid_muscles/BayesOpt_cuboid_2D.py
+++ b/opendihu_examples/paired_muscles/cuboid_muscles/BayesOpt_cuboid_2D.py
@@ -356,13 +356,20 @@ while continuing == "y":
 
     continuing = input("Do you want to add another query point? (y/n)")
 
-x_1 = np.linspace(bounds[0,0], bounds[1,0], 100)
-x_2 = np.linspace(bounds[0,1], bounds[1,1], 100)
+x_1 = np.linspace(0, 1, 100)
+x_2 = np.linspace(0, 1, 100)
 X, Y = np.meshgrid(x_1, x_2)
 XY = np.stack([X, Y], axis=-1)
 XY = XY.reshape(-1, 2)
 XY_torch = torch.tensor(XY, dtype=torch.float32)
 posterior = gp.posterior(XY_torch)
+
+x_1_real = np.linspace(bounds[0,0], bounds[1,0], 100)
+x_2_real = np.linspace(bounds[0,1], bounds[1,1], 100)
+X_real, Y_real = np.meshgrid(x_1_real, x_2_real)
+XY_real = np.stack([X_real, Y_real], axis=-1)
+XY_real = XY_real.reshape(-1, 2)
+XY_torch_real = torch.tensor(XY_real, dtype=torch.float32)
 
 mean = posterior.mean.squeeze(-1).detach().numpy()
 
@@ -372,7 +379,7 @@ best_y = initial_y[max_index]
 
 with open("BayesOpt_outputs"+global_individuality_parameter+".csv", "a", newline="") as f:
     writer = csv.writer(f)
-    writer.writerow(XY)
+    writer.writerow(XY_real)
     writer.writerow(mean)
     writer.writerow(["Number of trials",counter])
     writer.writerow(["Optimizer and Optimum",(maximizer[0]*(bounds[1,0]-bounds[0,0])+bounds[0,0]).numpy(), (maximizer[1]*(bounds[1,1]-bounds[0,1])+bounds[0,1]).numpy(), best_y.numpy()[0]])


### PR DESCRIPTION
## Main changes of this PR

**Issues that are addressed by this PR:** 
The 3d plot of the 2d optimization process did not look as it should. The mean function wasn't interpolating the trials correctly.

**Features that have been added:**


## Additional information
The bug occurred because of an implementation error inside of the optimization loop. It was working for the bounds [0,0] to [1,1], but not for any other bounds, now it does work (for a dummy function).

## Author's checklist

* [ ] I updated the documentation.
* [ ] I checked that everything compiles and runs as it should.